### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     // Mixin Squared to allow us to mixin directly to FTAPI's HBE mixin.
-    include(implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:${project.mixin_squared_version}")))
+    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${project.mixin_squared_version}")))
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     // Mixin Squared to allow us to mixin directly to FTAPI's HBE mixin.
-    include(implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:${project.mixin_squared_version}")))
+    include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${project.mixin_squared_version}")))
 }
 
 processResources {


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_